### PR TITLE
make handle_response funcs public

### DIFF
--- a/lib/soap.ex
+++ b/lib/soap.ex
@@ -59,13 +59,13 @@ defmodule Soap do
     wsdl.operations
   end
 
-  defp handle_response(
+  def handle_response(
          {:ok, %HTTPoison.Response{body: body, headers: headers, request_url: request_url, status_code: status_code}}
        ) do
     {:ok, %Response{body: body, headers: headers, request_url: request_url, status_code: status_code}}
   end
 
-  defp handle_response({:error, %HTTPoison.Error{reason: reason}}) do
+  def handle_response({:error, %HTTPoison.Error{reason: reason}}) do
     {:error, reason}
   end
 


### PR DESCRIPTION
this allows using response handler separately without having to go through `Soap.call` so that it would be easier to just use handle_response directly